### PR TITLE
Add search scraping fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@
 - **Keywords extraídas** de dados reais
 - **Score baseado** em informações verdadeiras
 
+> **Atenção**: as chaves de API são **opcionais**.
+> Caso defina `GOOGLE_API_KEY`, `GOOGLE_CX`, `YOUTUBE_API_KEY` e
+> `TWITTER_BEARER_TOKEN`, as buscas usam as APIs oficiais.
+> Sem essas chaves o aplicativo faz uma raspagem simples das páginas para
+> obter os resultados.
+
 ## 🔍 **Como Funciona a Busca REAL:**
 
 ### **🌐 Google Search Real:**


### PR DESCRIPTION
## Summary
- support Google/YouTube/Twitter scraping when API keys aren't provided
- document that API keys are optional

## Testing
- `python -m py_compile streamlit_app.py analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f57cc5b0832a8b917667f91fc983